### PR TITLE
JIT serializtion on DB objects

### DIFF
--- a/tests/DatabaseObjectTest.php
+++ b/tests/DatabaseObjectTest.php
@@ -35,7 +35,7 @@ class DatabaseObjectTest extends PHPUnit_Framework_TestCase {
 
 		$do->save();
 
-		$this->assertEquals($do->id, $newId);
+		$this->assertEquals($newId, $do->id);
 
 	}
 
@@ -99,13 +99,12 @@ class DatabaseObjectTest extends PHPUnit_Framework_TestCase {
 
 		$to = new TestObject(array(
 			'test' => '123',
-			'serialize' => array(1, 2, 3),
+			'serialize' => $class = new stdClass(),
 			'jsonize' => array(4, 5, 6)
 		));
 
 		$this->assertEquals($to->test, '123');
-		$this->assertEquals($to->serialize, array(1, 2, 3));
-		$this->assertEquals($to->serialize[2], 3);
+		$this->assertSame($to->serialize, $class);
 		$this->assertEquals($to->jsonize, array(4, 5, 6));
 		$this->assertEquals($to->jsonize[2], 6);
 


### PR DESCRIPTION
This update serializes and json-encodes the required columns for a DatabaseObject, just before it is saved. Data is kept in its natural state for as long as possible. This allows us, for example, to set an object to a parameter and continue to use it and retrieve it, without it being cloned in the serialization-deserialization process.